### PR TITLE
changed how to write url parameters

### DIFF
--- a/o365chk.py
+++ b/o365chk.py
@@ -4,11 +4,15 @@ import argparse
 
 
 def make_requests(target):
+    params = {
+        'login': 'username@' + str(target),
+        'json': '1'
+    }
 
-    url = 'https://login.microsoftonline.com/getuserrealm.srf?login=username@'+str(target)+'&json=1'
+    url = 'https://login.microsoftonline.com/getuserrealm.srf'
 
     try:
-        r = requests.get(url)
+        r = requests.get(url, params=params)
         r.raise_for_status()
     except requests.exceptions.HTTPError as errh:
         print("Http Error:", errh)


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Contents

* The url parameters are summarized in json

## Reasons

* The get function in the requests library has a `params` argument
* I think this is easier to read the program